### PR TITLE
Move Apache licence comment to end of .sln file

### DIFF
--- a/Usergrid.sln
+++ b/Usergrid.sln
@@ -1,18 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+# For licence details see end of file.
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Usergrid.Sdk.IntegrationTests", "Usergrid.Sdk.IntegrationTests\Usergrid.Sdk.IntegrationTests.csproj", "{0278A0A4-F5E9-41F7-A86E-CD376D3FE5E2}"
@@ -47,3 +33,17 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Visual Studio 2012 and 2015 will not open a solution file that starts with multi line comments. (I was not able to test other Visual Studio version, but I suspect the behavior would be the same). 

This change makes the solution file valid while retaining the licence information.